### PR TITLE
chore(ci): enable more build targets for cargo-dist

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -63,7 +63,7 @@ checksum = "7ffc183a10b4478d04cbbbfc96d0873219d962dd5accaff2ffbd4ceb7df837f4"
 
 [[package]]
 name = "rusty-cli"
-version = "0.1.0-pre-7"
+version = "0.1.0-pre-9"
 dependencies = [
  "libc",
  "nix",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rusty-cli"
-version = "0.1.0-pre-7"
+version = "0.1.0-pre-9"
 edition = "2021"
 authors = ["Michael Martin <flrgh@protonmail.com>"]
 license = "BSD-2-Clause"
@@ -40,16 +40,23 @@ unix-archive = ".tar.gz"
 targets = [
 	"x86_64-unknown-linux-gnu",
 	"x86_64-unknown-linux-musl",
-	#"aarch64-unknown-linux-gnu",
-	#"aarch64-unknown-linux-musl",
-	#"x86_64-apple-darwin",
-	#"aarch64-apple-darwin",
+	"aarch64-unknown-linux-gnu",
+	"aarch64-unknown-linux-musl",
+	"x86_64-apple-darwin",
+	"aarch64-apple-darwin",
 ]
+
+# cargo-dist buildjet runners for arm64
+[workspace.metadata.dist.github-custom-runners]
+aarch64-unknown-linux-gnu = "buildjet-8vcpu-ubuntu-2204-arm"
+aarch64-unknown-linux-musl = "buildjet-8vcpu-ubuntu-2204-arm"
 
 # cargo-release
 [workspace.metadata.release]
 sign-commit = true
 sign-tag = true
-push = true # git
+push = true
 tag = true
 consolidate-commits = true
+pre-release-commit-message = "release: {{version}}"
+tag-message = "release: {{version}}"

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -158,7 +158,7 @@ fn main_conf(user: &mut UserArgs) -> Vec<String> {
     conf
 }
 
-pub trait CliOpt {
+pub(crate) trait CliOpt {
     fn get_arg(&self, optarg: &mut Option<String>) -> Result<String, ArgError>;
 
     fn parse_to<T>(&self, value: &mut Option<String>) -> Result<T, ArgError>
@@ -235,14 +235,14 @@ fn include_file(section: &str, fname: String) -> Result<String, ArgError> {
 }
 
 #[derive(Debug, PartialEq, Eq)]
-pub enum Action {
+pub(crate) enum Action {
     Help,
     Version(Option<String>),
     Main(Box<UserArgs>),
 }
 
 impl Action {
-    pub fn run(self) -> i32 {
+    pub(crate) fn run(self) -> i32 {
         match self {
             Action::Help => {
                 println!("{}", USAGE);
@@ -353,7 +353,7 @@ impl Action {
 }
 
 #[derive(Default, Debug, PartialEq, Eq)]
-pub struct UserArgs {
+pub(crate) struct UserArgs {
     pub(crate) inline_lua: Vec<String>,
     pub(crate) lua_file: Option<String>,
     pub(crate) lua_args: Vec<String>,
@@ -397,7 +397,7 @@ fn discover_system_nameservers() -> Vec<IpAddr> {
 }
 
 impl Action {
-    pub fn try_from<T>(args: T) -> Result<Self, ArgError>
+    pub(crate) fn try_from<T>(args: T) -> Result<Self, ArgError>
     where
         T: IntoIterator<Item = String>,
     {


### PR DESCRIPTION
This adds Linux arm64 and Apple/Darwin as targets for cargo dist.

*NOTE:* these targets are yet untested