### PR TITLE
chore(deps): move cargo-{dist,release} to dev-dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,6 +61,6 @@ consolidate-commits = true
 pre-release-commit-message = "release: {{version}}"
 tag-message = "release: {{version}}"
 
-[build-dependencies]
+[dev-dependencies]
 cargo-dist = "0.14.0"
 cargo-release = "0.25.7"


### PR DESCRIPTION
These are more like release dependencies rather than `build` or `dev`, but moving them to `dev-dependencies` stops them from slowing down builds in CI.