### PR TITLE
chore(util): replace an unsafe libc::mkdtemp call

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ shlex = "1.3.0"
 strum = { version = "0.26", features = ["derive"] }
 strum_macros = "0.26"
 libc = "0.2"
-nix = { version = "0.29.0", features = ["signal", "process"] }
+nix = { version = "0.29.0", features = ["signal", "process", "fs", "feature"] }
 thiserror = "1.0.61"
 
 [profile.release]


### PR DESCRIPTION
Let nix do the unsafe stuff.