### PR TITLE
chore(cargo): forbid unsafe{} for all project code

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,9 @@ libc = "0.2"
 nix = { version = "0.29.0", features = ["signal", "process", "fs", "feature"] }
 thiserror = "1.0.61"
 
+[lints.rust]
+unsafe_code = "forbid"
+
 [profile.release]
 opt-level = "z"
 strip = true


### PR DESCRIPTION
Not sure if I'll always be able to keep it this way, but it's nice for now.