### PR TITLE
fix(build): inform cargo to expect custom default_nginx_path cfg

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -1,6 +1,7 @@
 use std::env;
 
 fn main() {
+    println!("cargo::rustc-check-cfg=cfg(default_nginx_path)");
     println!("cargo::rerun-if-env-changed=NGINX_PATH");
     if env::var("NGINX_PATH").is_ok_and(|nginx| !nginx.trim().is_empty()) {
         println!("cargo::rustc-cfg=default_nginx_path");


### PR DESCRIPTION
This stops clippy from complaining about it.

https://doc.rust-lang.org/nightly/rustc/check-cfg/cargo-specifics.html#cargorustc-check-cfg-for-buildrsbuild-script