### PR TITLE
test(compat): bump OpenResty 1.25.3.1 -> 1.25.3.2 in matrix

### DIFF
--- a/.github/workflows/test-compat.yml
+++ b/.github/workflows/test-compat.yml
@@ -48,7 +48,7 @@ jobs:
               --with-stream_ssl_module
               --with-stream_ssl_preread_module
 
-          - openresty: 1.25.3.1
+          - openresty: 1.25.3.2
             resty-cli: v0.30
             openssl: 1.1.1n
             openresty-opts: >


### PR DESCRIPTION
Updates the matrix to use the latest 1.25.3.x OpenResty release.