### PR TITLE
chore(ci): fix broken compat test builds

### DIFF
--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -44,6 +44,9 @@ runs:
         set-out build-mode   "${BUILD_MODE}"
         set-env BUILD_MODE   "${BUILD_MODE}"
 
+        set-out build-binary "$PWD/target/${BUILD_MODE}/rusty-cli"
+        set-env BUILD_BINARY "$PWD/target/${BUILD_MODE}/rusty-cli"
+
     - name: restore build cache
       id: cache-restore
       uses: actions/cache/restore@v4
@@ -96,21 +99,27 @@ runs:
         rm -rf ~/.cargo
         mv ./cargo-pre ~/.cargo
 
-    - name: check build result
-      id: check-build
+    - name: add binary directory to $PATH
+      id: update-path
       shell: bash
       run: |
-        BIN=./target/${BUILD_MODE}/rusty-cli
-        if [[ ! -e $BIN ]]; then
-          echo "ERROR: binary ($BIN) not found"
+        : "${BUILD_BINARY:?}"
+        if [[ ! -e $BUILD_BINARY || ! -x $BUILD_BINARY ]]; then
+          echo "ERROR: binary ($BUILD_BINARY) not found/not executable"
           exit 1
         fi
 
+        BIN_DIR=${BUILD_BINARY%/*}
+        PATH=${BIN_DIR}:${PATH}
+
         tmp=$(mktemp)
-        if ! "$BIN" --help &>"$tmp"; then
-          echo "ERROR: $BIN --help returned non-zero"
+        if ! rusty-cli --help &>"$tmp"; then
+          echo 'ERROR: `rusty-cli --help` returned non-zero'
           cat "$tmp"
+          exit 1
         fi
+
+        echo "$BIN_DIR" >> $GITHUB_PATH
 
     - name: update ~/.cargo contents
       id: cargo-restore

--- a/.github/workflows/test-compat.yml
+++ b/.github/workflows/test-compat.yml
@@ -19,6 +19,7 @@ jobs:
             openssl: 1.1.1n
             openresty-opts: >
               --with-compat
+              --with-pcre
               --with-pcre-jit
               --with-stream
               --with-threads
@@ -31,6 +32,7 @@ jobs:
             openssl: 1.1.1n
             openresty-opts: >
               --with-compat
+              --with-pcre
               --with-pcre-jit
               --with-stream
               --with-threads
@@ -43,6 +45,7 @@ jobs:
             openssl: 1.1.1w
             openresty-opts: >
               --with-compat
+              --with-pcre
               --with-pcre-jit
               --with-stream
               --with-threads
@@ -55,6 +58,7 @@ jobs:
             openssl: 3.0.15
             openresty-opts: >
               --with-compat
+              --with-pcre
               --with-pcre-jit
               --with-stream
               --with-threads

--- a/.github/workflows/test-compat.yml
+++ b/.github/workflows/test-compat.yml
@@ -143,7 +143,7 @@ jobs:
       - name: copy & patch files
         run: ./tests/setup-resty-cli.sh
 
-      - name: sanity (nginx -V <> rusty-cli -V)
+      - name: sanity (nginx -V <> rusty-cli -V <> resty -V)
         run: |
           split_args() {
             sed -r -e '/^configure arguments:.*/ s/ (--?)/\n\1/g'
@@ -155,6 +155,10 @@ jobs:
 
           echo "::group::rusty-cli -V"
           rusty-cli -V 2>&1 | split_args
+          echo "::endgroup::"
+
+          echo "::group::resty -V"
+          ./resty-cli/bin/resty -V 2>&1 | split_args
           echo "::endgroup::"
 
       - name: sanity (rusty-cli w/ gdb)

--- a/.github/workflows/test-compat.yml
+++ b/.github/workflows/test-compat.yml
@@ -143,15 +143,25 @@ jobs:
       - name: copy & patch files
         run: ./tests/setup-resty-cli.sh
 
-      - name: sanity 2
+      - name: sanity (nginx -V verses rusty-cli -V)
         run: |
-          ./target/debug/rusty-cli --help
+          split_args() {
+            sed -r -e '/^configure arguments:.*/ s/ (--?)/\n\1/g'
+          }
+
+          echo "::group::nginx -V"
+          nginx -V 2>&1 | split_args
+          echo "::endgroup::"
+
+          echo "::group::rusty-cli -V"
+          ./target/release/rusty-cli -V 2>&1 | split_args
+          echo "::endgroup::"
+
+      - name: sanity (rusty-cli w/ gdb)
+        run: |
           ./target/debug/rusty-cli \
              --gdb-opts="--nx -batch -ex 'b main' -ex run -ex bt -ex 'b lj_cf_io_method_write' -ex c -ex bt" \
              -e 'io.stderr:write("hello world!~~\n")'
-
-      - name: nginx info
-        run: nginx -V
 
       - name: prove
         run: prove -r t/

--- a/.github/workflows/test-compat.yml
+++ b/.github/workflows/test-compat.yml
@@ -143,7 +143,7 @@ jobs:
       - name: copy & patch files
         run: ./tests/setup-resty-cli.sh
 
-      - name: sanity (nginx -V verses rusty-cli -V)
+      - name: sanity (nginx -V <> rusty-cli -V)
         run: |
           split_args() {
             sed -r -e '/^configure arguments:.*/ s/ (--?)/\n\1/g'
@@ -154,12 +154,12 @@ jobs:
           echo "::endgroup::"
 
           echo "::group::rusty-cli -V"
-          ./target/release/rusty-cli -V 2>&1 | split_args
+          rusty-cli -V 2>&1 | split_args
           echo "::endgroup::"
 
       - name: sanity (rusty-cli w/ gdb)
         run: |
-          ./target/debug/rusty-cli \
+          rusty-cli \
              --gdb-opts="--nx -batch -ex 'b main' -ex run -ex bt -ex 'b lj_cf_io_method_write' -ex c -ex bt" \
              -e 'io.stderr:write("hello world!~~\n")'
 

--- a/.github/workflows/test-compat.yml
+++ b/.github/workflows/test-compat.yml
@@ -143,7 +143,13 @@ jobs:
       - name: copy & patch files
         run: ./tests/setup-resty-cli.sh
 
-      - name: sanity (nginx -V <> rusty-cli -V <> resty -V)
+      - name: debug (ldd nginx)
+        run: |
+          NGINX=$(realpath "$(type -p nginx)")
+          echo "nginx is $NGINX"
+          ldd "$NGINX"
+
+      - name: debug (nginx -V <> rusty-cli -V <> resty -V)
         run: |
           split_args() {
             sed -r -e '/^configure arguments:.*/ s/ (--?)/\n\1/g'
@@ -161,7 +167,7 @@ jobs:
           ./resty-cli/bin/resty -V 2>&1 | split_args
           echo "::endgroup::"
 
-      - name: sanity (rusty-cli w/ gdb)
+      - name: debug (rusty-cli w/ gdb)
         run: |
           rusty-cli \
              --gdb-opts="--nx -batch -ex 'b main' -ex run -ex bt -ex 'b lj_cf_io_method_write' -ex c -ex bt" \


### PR DESCRIPTION
`--with-pcre` must now be provided explicitly, else the default nginx.conf template will yield errors due to its use of `lua_regex_cache_max_entries`.