### PR TITLE
chore(ci): restore tests for old versions

### DIFF
--- a/.github/actions/setup-openresty/action.yml
+++ b/.github/actions/setup-openresty/action.yml
@@ -1,0 +1,175 @@
+name: setup OpenResty
+description: >-
+  Download, patch, and build OpenResty + OpenSSL, install Test::Nginx via
+  cpanm, cache the result, and put the install on PATH. Replaces
+  thibaultcha/setup-openresty for this repo's compat matrix.
+
+inputs:
+  version:
+    description: OpenResty version (e.g. 1.27.1.2)
+    required: true
+  openssl-version:
+    description: OpenSSL version (e.g. 1.1.1w or 3.4.1)
+    required: true
+
+outputs:
+  openresty-prefix:
+    description: Install prefix (also exported as $OPENRESTY_PREFIX)
+    value: ${{ steps.prep.outputs.prefix }}
+
+runs:
+  using: composite
+  steps:
+    - name: prepare
+      id: prep
+      shell: bash
+      env:
+        VERSION: ${{ inputs.version }}
+      run: |
+        set -euo pipefail
+        WORK="${GITHUB_WORKSPACE}/work"
+        PREFIX="${GITHUB_WORKSPACE}/openresty/${VERSION}"
+        mkdir -p "${WORK}"
+        echo "WORK=${WORK}"                                    >> "${GITHUB_ENV}"
+        echo "OPENRESTY_PREFIX=${PREFIX}"                      >> "${GITHUB_ENV}"
+        echo "PERL5LIB=${WORK}/lib/cpanm/lib/perl5"            >> "${GITHUB_ENV}"
+        echo "prefix=${PREFIX}"                                >> "${GITHUB_OUTPUT}"
+
+    - name: cache OpenResty
+      id: cache
+      uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
+      with:
+        path: |
+          ${{ env.OPENRESTY_PREFIX }}
+          work/
+        key: >-
+          ${{
+            format(
+              'v3::{0}-openresty-{1}-openssl-{2}-{3}',
+              runner.os,
+              inputs.version,
+              inputs.openssl-version,
+              hashFiles('.github/actions/setup-openresty/action.yml')
+            )
+          }}
+
+    - name: install build deps
+      if: steps.cache.outputs.cache-hit != 'true'
+      shell: bash
+      run: sudo apt-get install -y libpcre3-dev
+
+    - name: download + patch OpenSSL
+      if: steps.cache.outputs.cache-hit != 'true'
+      shell: bash
+      env:
+        OPENSSL_VERSION: ${{ inputs.openssl-version }}
+      run: |
+        set -euo pipefail
+        cd "${WORK}"
+
+        # openssl.org's 301 points at the lowercase `openssl-X.Y.Z` tag,
+        # which only exists for 3.x; 1.1.x uses `OpenSSL_X_Y_Zn`.
+        case "${OPENSSL_VERSION}" in
+          1.*) TAG="OpenSSL_${OPENSSL_VERSION//./_}" ;;
+          3.*) TAG="openssl-${OPENSSL_VERSION}" ;;
+          *) echo "::error::Unsupported OpenSSL version: ${OPENSSL_VERSION}"; exit 1 ;;
+        esac
+        curl -fsSLo openssl.tar.gz \
+          "https://github.com/openssl/openssl/releases/download/${TAG}/openssl-${OPENSSL_VERSION}.tar.gz"
+
+        rm -rf OpenSSL && mkdir OpenSSL
+        tar -xzf openssl.tar.gz -C OpenSSL --strip-components=1
+        rm -f openssl.tar.gz
+
+        # ngx_lua's session-resume cosocket path needs OpenResty's patch.
+        # Only 1.1.x in our matrix needs it; the patch tracks 1.1.1f for
+        # all 1.1.1[f-z]+ releases.
+        case "${OPENSSL_VERSION}" in
+          1.1.1[f-z]*)
+            PATCH_URL='https://raw.githubusercontent.com/openresty/openresty/master/patches/openssl-1.1.1f-sess_set_get_cb_yield.patch'
+            curl -fsSLo openssl.patch "${PATCH_URL}"
+            (cd OpenSSL && patch --forward -p1) < openssl.patch \
+              || echo "::warning::OpenSSL patch did not apply cleanly (continuing)"
+            rm -f openssl.patch
+            ;;
+        esac
+
+        echo "OPENSSL_SRC=${WORK}/OpenSSL" >> "${GITHUB_ENV}"
+
+    - name: download + build OpenResty
+      if: steps.cache.outputs.cache-hit != 'true'
+      shell: bash
+      env:
+        VERSION: ${{ inputs.version }}
+      run: |
+        set -euo pipefail
+        cd "${WORK}"
+
+        curl -fsSLo openresty.tar.gz \
+          "https://openresty.org/download/openresty-${VERSION}.tar.gz"
+        rm -rf OpenResty && mkdir OpenResty
+        tar -xzf openresty.tar.gz -C OpenResty --strip-components=1
+        rm -f openresty.tar.gz
+
+        IFS=. read -r MAJ MIN _ _ <<< "${VERSION}"
+
+        ARGS=(
+          "--builddir=${WORK}/build"
+          "--prefix=${OPENRESTY_PREFIX}"
+          "-j$(nproc)"
+          "--with-cc-opt=-g"
+          "--with-debug"
+          "--with-openssl=${OPENSSL_SRC}"
+          --with-compat
+          --with-pcre
+          --with-pcre-jit
+          --with-stream
+          --with-threads
+          --with-http_ssl_module
+          --with-stream_ssl_module
+          --with-stream_ssl_preread_module
+        )
+
+        # Old OpenResty bundles a PCRE rewrite module that fails to find
+        # PCRE on newer hosts. Disable it for pre-1.27.
+        if (( MAJ == 1 && MIN < 27 )); then
+          ARGS+=("--without-http_rewrite_module")
+        fi
+
+        echo "configure: ${ARGS[*]}"
+        cd OpenResty
+        ./configure "${ARGS[@]}"
+        make -j"$(nproc)"
+        make install
+
+    - name: install Test::Nginx via cpanm
+      if: steps.cache.outputs.cache-hit != 'true'
+      shell: bash
+      run: |
+        set -euo pipefail
+        DIR_CPAN="${WORK}/lib/cpanm"
+        mkdir -p "${DIR_CPAN}"
+        curl -fsSLo "${WORK}/cpanm" https://cpanmin.us
+        chmod +x "${WORK}/cpanm"
+        for mod in local::lib Test::Nginx IPC::Run IPC::Run3; do
+          "${WORK}/cpanm" --notest --local-lib="${DIR_CPAN}" "${mod}"
+        done
+
+    - name: cleanup build artifacts
+      if: steps.cache.outputs.cache-hit != 'true'
+      shell: bash
+      run: |
+        rm -rf \
+          "${WORK}/OpenResty" \
+          "${WORK}/OpenSSL/test" \
+          "${WORK}/OpenSSL/doc" \
+          "${WORK}/OpenSSL/demos" \
+          "${WORK}/OpenSSL/fuzz" \
+          || true
+
+    - name: add OpenResty to PATH
+      shell: bash
+      run: |
+        echo "${OPENRESTY_PREFIX}/bin"        >> "${GITHUB_PATH}"
+        echo "${OPENRESTY_PREFIX}/luajit/bin" >> "${GITHUB_PATH}"
+        echo "${OPENRESTY_PREFIX}/nginx/sbin" >> "${GITHUB_PATH}"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,7 @@ updates:
       - "/"
       - ".github/actions/build"
       - ".github/actions/setup"
+      - ".github/actions/setup-openresty"
     schedule:
       interval: "weekly"
 

--- a/.github/workflows/test-compat.yml
+++ b/.github/workflows/test-compat.yml
@@ -24,24 +24,28 @@ jobs:
             | [
                 {
                   openresty: "1.19.9.1",
+                  openssl: "1.1.1n",
                   cli: [
                     "v0.28"
                   ]
                 },
                 {
                   openresty: "1.21.4.3",
+                  openssl: "1.1.1w",
                   cli: [
                     "v0.29"
                   ]
                 },
                 {
                   openresty: "1.25.3.2",
+                  openssl: "1.1.1w",
                   cli: [
                     "v0.29"
                   ]
                 },
                 {
                   openresty: "1.27.1.2",
+                  openssl: "3.4.1",
                   cli: [
                     "v0.29",
                     "v0.30",
@@ -51,6 +55,7 @@ jobs:
                 },
                 {
                   openresty: "1.29.2.1",
+                  openssl: "3.5.5",
                   cli: [
                     "v0.32"
                   ]
@@ -60,11 +65,13 @@ jobs:
             | reduce (
                 $RESTY_META[]
                 | .openresty as $openresty
+                | .openssl as $openssl
                 | {
                     $openresty,
+                    $openssl,
                     cli: .cli[]
                   }
-              ) as { $openresty, $cli }
+              ) as { $openresty, $openssl, $cli }
               (
                 {
                   label: [],
@@ -77,6 +84,7 @@ jobs:
                 | .include += [{
                     $label,
                     $openresty,
+                    $openssl,
                     "resty-cli": $cli,
                   }]
               )
@@ -103,13 +111,6 @@ jobs:
 
     env:
       RESTY_CLI_COMPAT_VERSION: ${{ matrix.resty-cli }}
-      RESTY_BUILD_OPTS: >
-        --with-compat
-        --with-pcre
-        --with-pcre-jit
-        --with-stream
-        --with-threads
-      RESTY_VERSION: ${{ matrix.openresty }}
 
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
@@ -122,54 +123,11 @@ jobs:
           sudo apt-get install -y gdb libpcre3
           gdb --version
 
-      - name: set OpenResty prefix
-        run: |
-          echo OPENRESTY_PREFIX=${GITHUB_WORKSPACE}/openresty/${RESTY_VERSION:?} >> $GITHUB_ENV
-          echo PERL5LIB=${GITHUB_WORKSPACE}/work/lib/cpanm/lib/perl5 >> $GITHUB_ENV
-
-      - name: Store OpenResty build opts
-        run: |
-          > .resty-opts
-          echo "${RESTY_BUILD_OPTS:?}"          >> .resty-opts
-
-      - name: cache OpenResty
-        uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
-        id: cache-openresty
-        with:
-          path: |
-            ${{ env.OPENRESTY_PREFIX }}
-            work/
-          key: v2::${{ runner.os }}-openresty-${{ matrix.openresty }}-${{ hashFiles('.resty-opts') }}
-
-      - name: install OpenResty build deps
-        if: steps.cache-openresty.outputs.cache-hit != 'true'
-        id: openresty-deps
-        run: |
-          sudo apt-get install -y libpcre3-dev
-
       - name: setup OpenResty
-        if: steps.cache-openresty.outputs.cache-hit != 'true'
-        id: setup-openresty
-        uses: thibaultcha/setup-openresty@3cf62bb9f63cca0c3e77e770d0313560d28b8023 # main
+        uses: ./.github/actions/setup-openresty
         with:
           version: ${{ matrix.openresty }}
-          test-nginx: true
-          debug: true
-          opt: ${{ env.RESTY_BUILD_OPTS }}
-
-      - name: Cleanup OpenResty build artifacts
-        if: steps.cache-openresty.outputs.cache-hit != 'true'
-        run: |
-          rm -rf \
-            ./work/OpenResty \
-            ./work/downloads \
-          || true
-
-      - name: add OpenResty bin dirs to PATH
-        run: |
-          echo ${OPENRESTY_PREFIX}/bin >> $GITHUB_PATH
-          echo ${OPENRESTY_PREFIX}/luajit/bin >> $GITHUB_PATH
-          echo ${OPENRESTY_PREFIX}/nginx/sbin >> $GITHUB_PATH
+          openssl-version: ${{ matrix.openssl }}
 
       - name: checkout resty-cli repo
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0

--- a/.github/workflows/test-compat.yml
+++ b/.github/workflows/test-compat.yml
@@ -23,8 +23,25 @@ jobs:
 
             | [
                 {
+                  openresty: "1.19.9.1",
+                  cli: [
+                    "v0.28"
+                  ]
+                },
+                {
+                  openresty: "1.21.4.3",
+                  cli: [
+                    "v0.29"
+                  ]
+                },
+                {
+                  openresty: "1.25.3.2",
+                  cli: [
+                    "v0.29"
+                  ]
+                },
+                {
                   openresty: "1.27.1.2",
-                  openssl: "3.4.1",
                   cli: [
                     "v0.29",
                     "v0.30",
@@ -34,7 +51,6 @@ jobs:
                 },
                 {
                   openresty: "1.29.2.1",
-                  openssl: "3.5.5",
                   cli: [
                     "v0.32"
                   ]
@@ -44,13 +60,11 @@ jobs:
             | reduce (
                 $RESTY_META[]
                 | .openresty as $openresty
-                | .openssl as $openssl
                 | {
                     $openresty,
-                    $openssl,
                     cli: .cli[]
                   }
-              ) as { $openresty, $openssl, $cli }
+              ) as { $openresty, $cli }
               (
                 {
                   label: [],
@@ -63,7 +77,6 @@ jobs:
                 | .include += [{
                     $label,
                     $openresty,
-                    $openssl,
                     "resty-cli": $cli,
                   }]
               )
@@ -96,10 +109,6 @@ jobs:
         --with-pcre-jit
         --with-stream
         --with-threads
-        --with-http_ssl_module
-        --with-stream_ssl_module
-        --with-stream_ssl_preread_module
-      RESTY_OPENSSL_VERSION: ${{ matrix.openssl }}
       RESTY_VERSION: ${{ matrix.openresty }}
 
     steps:
@@ -122,7 +131,6 @@ jobs:
         run: |
           > .resty-opts
           echo "${RESTY_BUILD_OPTS:?}"          >> .resty-opts
-          echo "${RESTY_OPENSSL_VERSION:?}"     >> .resty-opts
 
       - name: cache OpenResty
         uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
@@ -145,7 +153,6 @@ jobs:
         uses: thibaultcha/setup-openresty@3cf62bb9f63cca0c3e77e770d0313560d28b8023 # main
         with:
           version: ${{ matrix.openresty }}
-          openssl-version: ${{ matrix.openssl }}
           test-nginx: true
           debug: true
           opt: ${{ env.RESTY_BUILD_OPTS }}
@@ -155,11 +162,6 @@ jobs:
         run: |
           rm -rf \
             ./work/OpenResty \
-            ./work/OpenSSL/test \
-            ./work/OpenSSL/doc \
-            ./work/OpenSSL/test \
-            ./work/OpenSSL/demos \
-            ./work/OpenSSL/fuzz \
             ./work/downloads \
           || true
 


### PR DESCRIPTION
Replace the borked OpenResty setup and re-enable tests for old versions.